### PR TITLE
Update image and thumbnail hosts

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -34,8 +34,8 @@ import { Agent as SSLAgent, } from 'https';
 function processOptions({
 	hosts: {
 		api    = 'nhentai.net',
-		images = 'i.nhentai.net',
-		thumbs = 't.nhentai.net',
+		images = 'i1.nhentai.net',
+		thumbs = 't1.nhentai.net',
 	} = {},
 	ssl   = true,
 	agent = null,


### PR DESCRIPTION
Image URLs broke because of a change in nhentai.

The images host changed from `i.nhentai.net` to `i1.nhentai.net`, `i2.nhentai.net`, `i3..nhentai.net` and `i4.nhentai.net`
The thumbnails host changed from `t.nhentai.net` to `t1.nhentai.net`, `t2.nhentai.net`, `t3.nhentai.net` and `t4.nhentai.net`

There appears to be no difference between any of the image/thumbnail hosts. I've set them all to the first one for now.

At the moment, users need to manually set the nHentaiOptions when initiating the API. This commit fixes that.